### PR TITLE
convert exposure date to local time for display to user

### DIFF
--- a/app/src/main/java/org/covidwatch/android/data/model/CovidExposureInformation.kt
+++ b/app/src/main/java/org/covidwatch/android/data/model/CovidExposureInformation.kt
@@ -11,6 +11,7 @@ import org.covidwatch.android.data.converter.AttenuationDurationsConverter
 import org.covidwatch.android.data.converter.ExposureConfigurationConverter
 import java.io.Serializable
 import java.time.Instant
+import java.time.ZoneId
 
 @Entity(tableName = "exposure_information")
 @TypeConverters(value = [AttenuationDurationsConverter::class, ExposureConfigurationConverter::class])
@@ -56,4 +57,8 @@ data class CovidExposureInformation(
 
     @Ignore
     val highRisk = riskScoreLevel == RiskLevel.HIGH
+
+    // date converted to to local time per the device's set time zone, for display purposes only
+    val localDate: Instant
+        get() = date.atZone(ZoneId.systemDefault()).toInstant()
 }

--- a/app/src/main/res/layout/exposure_details.xml
+++ b/app/src/main/res/layout/exposure_details.xml
@@ -53,7 +53,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_normal"
-            app:exposure_details_date="@{exposure.date}"
+            app:exposure_details_date="@{exposure.localDate}"
             tools:text="On May 23, 2020 you were near someone who shared a positive and verified diagnosis of COVID-19. " />
     </LinearLayout>
 </layout>


### PR DESCRIPTION
translate exposure date to a user's local time per their device time zone, strictly for display only